### PR TITLE
For 5 years inactive package NumericAnnex replaced by NumberKit package

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -28,15 +28,6 @@
       }
     },
     {
-      "identity" : "numericannex",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/xwu/NumericAnnex.git",
-      "state" : {
-        "branch" : "master",
-        "revision" : "ff00a9ad3c7c9632a149ac3114936dbc9dabae01"
-      }
-    },
-    {
       "identity" : "quick",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Quick/Quick.git",
@@ -61,6 +52,15 @@
       "state" : {
         "revision" : "3303b164430d9a7055ba484c8ead67a52f7b74f6",
         "version" : "1.0.0"
+      }
+    },
+    {
+      "identity" : "swift-numberkit",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/objecthub/swift-numberkit",
+      "state" : {
+        "revision" : "0f9c918dcea73f6ff4ff762b8e83a0991ca668d9",
+        "version" : "2.4.2"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         .package(url: "https://github.com/Quick/Quick.git", .upToNextMajor(from: "4.0.0")),
         .package(url: "https://github.com/Quick/Nimble.git", .upToNextMajor(from: "9.2.0")),
-        .package(url: "https://github.com/xwu/NumericAnnex.git", branch: "master"),
+        .package(url: "https://github.com/objecthub/swift-numberkit.git", from: "2.4.2"),
         .package(url: "https://github.com/sharplet/Regex.git", from: "2.1.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
     ],
@@ -27,7 +27,7 @@ let package = Package(
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
             name: "SwiftMETAR",
-            dependencies: ["NumericAnnex", "Regex"],
+            dependencies: [.product(name: "NumberKit", package: "swift-numberkit"), "Regex"],
             resources: [.process("Resources")]),
         .testTarget(
             name: "SwiftMETARTests",

--- a/Sources/SwiftMETAR/Common/Parsers/VisibilityParser.swift
+++ b/Sources/SwiftMETAR/Common/Parsers/VisibilityParser.swift
@@ -1,13 +1,13 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 import Regex
 
-fileprivate let fractionalRx = Regex(#"^([PM])?(\d+)\/(\d+)SM$"#)
-fileprivate let integerRx = Regex(#"^([PM])?(\d+)(SM|FT|M)$"#)
-fileprivate let metersRx = Regex(#"^(\d{3,4})$"#)
-fileprivate let notRecordedRx = Regex(#"^\/{2,}(SM|FT|M)$"#)
+private let fractionalRx = Regex(#"^([PM])?(\d+)\/(\d+)SM$"#)
+private let integerRx = Regex(#"^([PM])?(\d+)(SM|FT|M)$"#)
+private let metersRx = Regex(#"^(\d{3,4})$"#)
+private let notRecordedRx = Regex(#"^\/{2,}(SM|FT|M)$"#)
 
-func parseVisibility(_ parts: inout Array<String.SubSequence>) throws -> Visibility? {
+func parseVisibility(_ parts: inout [String.SubSequence]) throws -> Visibility? {
     guard !parts.isEmpty else { return nil }
     let vizStr = String(parts[0])
     
@@ -37,7 +37,7 @@ func parseVisibility(_ parts: inout Array<String.SubSequence>) throws -> Visibil
         if let fractionalParts = try parseFraction(vizStr2) {
             parts.removeFirst()
             
-            let value = Ratio(numerator: Int(whole), denominator: 1) + fractionalParts.value
+            let value = Ratio(Int(whole), 1) + fractionalParts.value
             switch fractionalParts.rangeValue {
                 case .lessThan: return .lessThan(.statuteMiles(value))
                 case .equal: return .equal(.statuteMiles(value))
@@ -58,7 +58,7 @@ func parseVisibility(_ parts: inout Array<String.SubSequence>) throws -> Visibil
         
         switch integerParts.units {
             case "SM":
-                let value = Ratio(numerator: Int(integerParts.value), denominator: 1)
+                let value = Ratio(Int(integerParts.value), 1)
                 switch integerParts.rangeValue {
                     case .lessThan: return .lessThan(.statuteMiles(value))
                     case .equal: return .equal(.statuteMiles(value))
@@ -85,16 +85,16 @@ func parseVisibility(_ parts: inout Array<String.SubSequence>) throws -> Visibil
     }
 }
 
-fileprivate enum RangeValue {
+private enum RangeValue {
     case lessThan, equal, greaterThan
 }
 
-fileprivate struct FractionResult {
+private struct FractionResult {
     let value: Ratio
     let rangeValue: RangeValue
 }
 
-fileprivate func parseFraction(_ string: String) throws -> FractionResult? {
+private func parseFraction(_ string: String) throws -> FractionResult? {
     var rangeValue = RangeValue.equal
     
     if let match = fractionalRx.firstMatch(in: string) {
@@ -111,20 +111,20 @@ fileprivate func parseFraction(_ string: String) throws -> FractionResult? {
               let denStr = match.captures[2],
               let denominator = UInt8(denStr) else { throw Error.invalidVisibility(string) }
         
-        return FractionResult(value: Ratio(numerator: Int(numerator), denominator: Int(denominator)),
+        return FractionResult(value: Ratio(Int(numerator), Int(denominator)),
                               rangeValue: rangeValue)
     }
     
     return nil
 }
 
-fileprivate struct IntegerResult {
+private struct IntegerResult {
     let value: UInt16
     let units: String
     let rangeValue: RangeValue
 }
 
-fileprivate func parseInteger(_ string: String) throws -> IntegerResult? {
+private func parseInteger(_ string: String) throws -> IntegerResult? {
     var rangeValue = RangeValue.equal
     
     if let match = integerRx.firstMatch(in: string) {

--- a/Sources/SwiftMETAR/Common/Visibility.swift
+++ b/Sources/SwiftMETAR/Common/Visibility.swift
@@ -1,4 +1,4 @@
-import NumericAnnex
+import NumberKit
 
 /// A visibility report, made by a human or a transmissometer.
 public enum Visibility: Codable, Equatable {

--- a/Sources/SwiftMETAR/METAR/Parsers/RemarkParser.swift
+++ b/Sources/SwiftMETAR/METAR/Parsers/RemarkParser.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 import Regex
 
 let directionFromString: Dictionary<String, Remark.Direction> = [
@@ -107,19 +107,19 @@ extension RemarkParser {
             guard let whole = UInt(wholeStr),
                   let num = UInt(numStr),
                   let den = UInt(denStr) else { return nil }
-            return .init(numerator: Int(whole*den+num), denominator: Int(den))
+            return .init(Int(whole*den+num), Int(den))
         }
         
         if let numStr = match.captures[index+3],
            let denStr = match.captures[index+4] {
             guard let num = UInt(numStr),
                   let den = UInt(denStr) else { return nil }
-            return .init(numerator: Int(num), denominator: Int(den))
+            return .init(Int(num), Int(den))
         }
         
         if let wholeStr = match.captures[index+5] {
             guard let whole = UInt(wholeStr) else { return nil }
-            return .init(numerator: Int(whole), denominator: 1)
+            return .init(Int(whole), 1)
         }
         
         return nil

--- a/Sources/SwiftMETAR/METAR/Remark.swift
+++ b/Sources/SwiftMETAR/METAR/Remark.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 
 /// Types of METAR remarks.
 public enum Remark: Codable, Equatable {

--- a/Sources/SwiftMETAR/Support/Ratio.swift
+++ b/Sources/SwiftMETAR/Support/Ratio.swift
@@ -1,0 +1,17 @@
+//
+//  File.swift
+//
+//
+//  Created by Régis Derimay on 17/01/2023.
+//
+
+import Foundation
+import NumberKit
+
+public typealias Ratio = Rational<Int>
+
+extension Float {
+    init(_ ratio: Ratio) {
+        self = ratio.floatValue
+    }
+}

--- a/Tests/SwiftMETARTests/METAR/Remarks/CorrectionSpec.swift
+++ b/Tests/SwiftMETARTests/METAR/Remarks/CorrectionSpec.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 import Quick
 import Nimble
 

--- a/Tests/SwiftMETARTests/METAR/Remarks/HailstoneSizeSpec.swift
+++ b/Tests/SwiftMETARTests/METAR/Remarks/HailstoneSizeSpec.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 import Quick
 import Nimble
 

--- a/Tests/SwiftMETARTests/METAR/Remarks/NextSpec.swift
+++ b/Tests/SwiftMETARTests/METAR/Remarks/NextSpec.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 import Quick
 import Nimble
 

--- a/Tests/SwiftMETARTests/METAR/Remarks/NoAmendmentsAfterSpec.swift
+++ b/Tests/SwiftMETARTests/METAR/Remarks/NoAmendmentsAfterSpec.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 import Quick
 import Nimble
 

--- a/Tests/SwiftMETARTests/METAR/Remarks/ObservedVisibilitySpec.swift
+++ b/Tests/SwiftMETARTests/METAR/Remarks/ObservedVisibilitySpec.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 import Quick
 import Nimble
 

--- a/Tests/SwiftMETARTests/METAR/Remarks/RelativeHumiditySpec.swift
+++ b/Tests/SwiftMETARTests/METAR/Remarks/RelativeHumiditySpec.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 import Quick
 import Nimble
 

--- a/Tests/SwiftMETARTests/METAR/Remarks/RunwayVisibilitySpec.swift
+++ b/Tests/SwiftMETARTests/METAR/Remarks/RunwayVisibilitySpec.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 import Quick
 import Nimble
 

--- a/Tests/SwiftMETARTests/METAR/Remarks/SectorVisibilitySpec.swift
+++ b/Tests/SwiftMETARTests/METAR/Remarks/SectorVisibilitySpec.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 import Quick
 import Nimble
 

--- a/Tests/SwiftMETARTests/METAR/Remarks/VariablePrevailingVisibilitySpec.swift
+++ b/Tests/SwiftMETARTests/METAR/Remarks/VariablePrevailingVisibilitySpec.swift
@@ -1,7 +1,7 @@
 import Foundation
+import NumberKit
 import Quick
 import Nimble
-import NumericAnnex
 
 @testable import SwiftMETAR
 

--- a/Tests/SwiftMETARTests/METAR/VisibilitySpec.swift
+++ b/Tests/SwiftMETARTests/METAR/VisibilitySpec.swift
@@ -1,5 +1,5 @@
 import Foundation
-import NumericAnnex
+import NumberKit
 import Quick
 import Nimble
 


### PR DESCRIPTION
As NumericAnnex is not maintained since a long time and makes problems when compiling on some targets, I replaced it by the NumberKit package. 
NumericAnnex was used only for the purpose of Rational numbers.
No other change.