### PR TITLE
Period Range End of Month Incorrect

### DIFF
--- a/Sources/SwiftMETAR/Support/DateComponentsInterval.swift
+++ b/Sources/SwiftMETAR/Support/DateComponentsInterval.swift
@@ -16,6 +16,22 @@ public struct DateComponentsInterval: Comparable, Hashable, Codable {
     public init(start: DateComponents, end: DateComponents) {
         self.start = start
         self.end = end
+        
+        fixEndDateShouldRollForwardOneMonth()
+    }
+    
+    /**
+     If the endDate rolled over to the first day of the month of the startDate, shift it forward one month.
+     */
+    private mutating func fixEndDateShouldRollForwardOneMonth() {
+        if let startDate = start.date,
+           let endDate = end.date,
+           startDate > endDate,
+           end.day == 1,
+           end.month == start.month,
+           let adjustedEndDate = zuluCal.date(byAdding: .month, value: 1, to: endDate){
+            self.end = zuluCal.dateComponents(in: zulu, from: adjustedEndDate)
+        }
     }
     
     public init(start: DateComponents, duration: TimeInterval) {

--- a/Tests/SwiftMETARTests/TAF/PeriodSpec.swift
+++ b/Tests/SwiftMETARTests/TAF/PeriodSpec.swift
@@ -1,0 +1,27 @@
+import Quick
+import Nimble
+import Foundation
+
+@testable import SwiftMETAR
+
+class PeriodSpec: QuickSpec {
+    override func spec() {
+        it("parses taf with group that crosses month boundary") {
+            let string = """
+            TAF KDVT 311746Z 3118/0118 12007KT P6SM -RA SCT030 OVC050 TEMPO 3118/3119 4SM RA BR BKN020 OVC040 FM311900 13008KT P6SM VCSH SCT030 OVC050 FM312200 12009KT P6SM SCT030 BKN060 FM010800 23010KT P6SM -SHRA VCTS SCT040 OVC050CB PROB30 0108/0112 4SM -TSRA BR OVC040CB
+            """
+            let referenceDate = Date(timeIntervalSince1970: 1711911482) //Sunday, March 31, 2024 6:58:02 PM Zulu
+            let forecast = try! TAF.from(string: string, on: referenceDate)
+            let firstPeriod = forecast.groups.first!.period
+            switch(firstPeriod) {
+            case .range(period: let period):
+                expect(period.start.day).to(equal(31))
+                expect(period.start.month).to(equal(3))
+                expect(period.end.day).to(equal(1))
+                expect(period.end.month).to(equal(4))
+            default:
+                fail("Expected first period to be of type .range")
+            }
+        }
+    }
+}


### PR DESCRIPTION
When a period is being parsed on the last day of the month, the endDate is being set to the first day of the same month as the startDate, which means the endDate comes before the startDate.  This change moves the endDate one month forward if this happens.